### PR TITLE
fix: add 1 second timeout and silent fail for importAccount sequence when the .popover-header__button element is not found

### DIFF
--- a/dappetter/src/index.ts
+++ b/dappetter/src/index.ts
@@ -335,13 +335,19 @@ async function importAccount(metamaskPage: puppeteer.Page, seed: string, passwor
   const doneButton = await metamaskPage.waitForSelector('.end-of-flow button')
   await doneButton.click()
 
-  const closeSwappingButton = await metamaskPage.waitForSelector('.popover-header__button')
-  await closeSwappingButton.click()
+  try {
+    const closeSwappingButton = await metamaskPage.waitForSelector('.popover-header__button', {
+      timeout: 1000,
+    })
+    await closeSwappingButton.click()
 
-  // Ensure popover is closed before continue
-  await metamaskPage.waitForFunction(() => {
-    return document.querySelector('.popover-header__button') == null
-  })
+    // Ensure popover is closed before continue
+    await metamaskPage.waitForFunction(() => {
+      return document.querySelector('.popover-header__button') == null
+    })
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 async function waitForUnlockedScreen(metamaskPage) {


### PR DESCRIPTION
Just testing this repo out with a headful Chrome via CodeceptJS.

When calling `dappetter.getMetamask(browser)`, the page successfully opens and gets through the flow. However, the browser appears to hang at the end. I tracked this down to Puppeteer waiting for the `.popover-header__button` element and not finding it.

This PR will timeout that request after 1 second and fail with a error log to the `console`.

I don't have any experience with MetaMask, so I don't know if this behaviour is something scoped to my particular use of it, or something else.